### PR TITLE
docs: add cspell to CI

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -3,9 +3,6 @@
 # https://www.streetsidesoftware.com/vscode-spell-checker/docs/configuration/
 version: '0.2'
 caseSensitive: false
-# words here are only listed for their spelling, if there is a certain way
-# to write a word (e.g. OpenTelemetry vs Opentelemetry or cloud native vs
-# cloud-native), edit the text-lint rules in .textlintrc.yml
 patterns:
   - name: CodeBlock
     pattern: |

--- a/.cspell.yml
+++ b/.cspell.yml
@@ -1,0 +1,86 @@
+# cSpell:ignore textlintrc
+# For settings, see
+# https://www.streetsidesoftware.com/vscode-spell-checker/docs/configuration/
+version: '0.2'
+caseSensitive: false
+# words here are only listed for their spelling, if there is a certain way
+# to write a word (e.g. OpenTelemetry vs Opentelemetry or cloud native vs
+# cloud-native), edit the text-lint rules in .textlintrc.yml
+patterns:
+  - name: CodeBlock
+    pattern: |
+      /
+          ^(\s*[~`]{3,})   # code-block start
+          .*               # all languages and options, e.g. shell {hl_lines=[12]}
+          [\s\S]*?         # content
+          \1               # code-block end
+      /igmx
+languageSettings:
+  - languageId: markdown
+    ignoreRegExpList:
+      - CodeBlock
+words:
+  - AWSX
+  - Azuma
+  - backports
+  - behaviour
+  - Bogsanyi
+  - callables
+  - circleci
+  - Clientcontext
+  - codeowners
+  - dalli
+  - datadog
+  - enqueuers
+  - ethon
+  - excon
+  - faas
+  - fanout
+  - faraday
+  - gettime
+  - gemfile
+  - Gitter
+  - gruf
+  - HTTPX
+  - httpx
+  - instrumenter
+  - Laurin
+  - Lightstep
+  - linux
+  - lmdb
+  - microbenchmarks
+  - Mustin
+  - myapp
+  - namespacing
+  - opentelemetry
+  - otelcol
+  - ottrace
+  - postgres
+  - postgresql
+  - racecar
+  - rabbitmq
+  - Railtie
+  - Rakefile
+  - Reopelle
+  - rdkafka
+  - resque
+  - restclient
+  - Robb
+  - rubocop
+  - rubydocs
+  - ruboproof
+  - rubygems
+  - Šimánek
+  - semconv
+  - sidekiq
+  - sinatra
+  - Solarwinds
+  - spanid
+  - toolset
+  - traceid
+  - traceresponse
+  - Untrace
+  - vitess
+  - webmocks
+  - Xuan
+  - yardoc

--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -1,0 +1,17 @@
+name: Spelling
+
+on:
+  pull_request:
+
+jobs:
+  spelling-check:
+    name: SPELLING check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: streetsidesoftware/cspell-action@v6
+        with:
+          # Files should be consistent with check:spelling files
+          files: |
+            **/*.md
+          config: .cspell.yml

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ multiple instrumentation libraries.
 - [SQL Obfuscation](helpers/sql-obfuscation/)
 ## Additional Libraries
 
-This repository also contains libraries to aid with interoperablity with vendor specific tracing solutions:
+This repository also contains libraries to aid with interoperability with vendor specific tracing solutions:
 
 - [Context Propagation](propagator/): OTTrace and Amazon X-Ray
 - [Resource Detectors](resources/):
@@ -74,18 +74,18 @@ This repository also contains libraries to aid with interoperablity with vendor 
 
 OpenTelemetry Ruby follows the [versioning and stability document][otel-versioning] in the OpenTelemetry specification. Notably, we adhere to the outlined version numbering exception, which states that experimental signals may have a `0.x` version number.
 
-### Library Compatability
+### Library Compatibility
 
-This project is managed on a volunteer basis and therefore we have limited capacity to support compatability with unmaintained or EOL libraries.
+This project is managed on a volunteer basis and therefore we have limited capacity to support compatibility with unmaintained or EOL libraries.
 
-We will regularly review the instrumentations to drop compatability for any versions of Ruby or gems that reach EOL or no longer receive regular maintenance.
+We will regularly review the instrumentations to drop compatibility for any versions of Ruby or gems that reach EOL or no longer receive regular maintenance.
 
 Should you need instrumentation for _older_ versions of a library then you must pin to a specific version of the instrumentation that supports it,
 however, you will no longer receive any updates for the instrumentation from this repository.
 
 > When a release series is no longer supported, it's your own responsibility to deal with bugs and security issues. We may provide backports of the fixes and publish them to git, however there will be no new versions released. If you are not comfortable maintaining your own versions, you should upgrade to a supported version. <https://guides.rubyonrails.org/maintenance_policy.html#security-issues>
 
-Consult instrumentation gem's README file and gemspec for details about library compatability.
+Consult instrumentation gem's README file and gemspec for details about library compatibility.
 
 ### Releases
 

--- a/instrumentation/CONTRIBUTING.md
+++ b/instrumentation/CONTRIBUTING.md
@@ -173,7 +173,7 @@ For example, the `Werewolf` module generated in the example above is available v
 
 Whenever possible, use first-party extension points (hooks) to instrument libraries. This ensures that the instrumentation is compatible with the latest versions of the library and that the instrumentation is maintained by the library authors. [`ActiveSupport::Notifications`](https://guides.rubyonrails.org/active_support_instrumentation.html) and `Middleware` are good examples of first-party extension points used by our instrumentation libraries.
 
-Monkey patching is discouraged in OpenTelemetry Ruby because it is the most common source of bugs and incompatability with the libraries we instrument. If you must monkey patch, please ensure that the monkey patch is as isolated as possible and that it is clearly documented.
+Monkey patching is discouraged in OpenTelemetry Ruby because it is the most common source of bugs and incompatibility with the libraries we instrument. If you must monkey patch, please ensure that the monkey patch is as isolated as possible and that it is clearly documented.
 
 ### Use Semantic Conventions
 
@@ -337,7 +337,7 @@ Add the service container to `jobs/instrumentation_with_services/services` and a
 
 > :information_source: Please refer to the official [GitHub Actions Documentation](https://docs.github.com/en/actions/using-containerized-services/about-service-containers) for more information on how to add a service container.
 
-If we determine the service container slows down the test suite significantly, it may make sense to copy the marix and steps stanzas from an existing instrumentation and update it to use the new service container as a dependency:
+If we determine the service container slows down the test suite significantly, it may make sense to copy the matrix and steps stanzas from an existing instrumentation and update it to use the new service container as a dependency:
 
 ```yaml
 
@@ -407,7 +407,7 @@ In addition to that, there should also be redundant `yardoc` comments in the ent
 
 ### Examples
 
-Executuable examples should be included in the `examples` directory that demonstrate how to use the instrumentation in a real-world scenario.
+Executable examples should be included in the `examples` directory that demonstrate how to use the instrumentation in a real-world scenario.
 
 We recommend using [Bundler's inline gemfile](https://bundler.io/guides/bundler_in_a_single_file_ruby_script.html) to run the examples. Here is an example from the `grape` instrumentation:
 

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -40,14 +40,14 @@ Instrumentation-specific documentation can be found in each subdirectory's `READ
 
 You also have the option of installing all of the instrumentation libraries by installing `opentelemetry-instrumentation-all`.  See that gem's [README](https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/all) for more.
 
-### Maintenance and Version Compatability
+### Maintenance and Version Compatibility
 
 We are a community of volunteers who do our best to provide our users with up to date support for instrumentations,
-however we have limited capacity and are unable to support compatability with EOL or unmaintained libraries.
+however we have limited capacity and are unable to support compatibility with EOL or unmaintained libraries.
 
 Should you need to instrument an _older_ version of a library you will have to ensure to pin to an instrumentation version that is compatible with that library.
 
-Please review the individual instrumentation READMEs for more information about version compatability.
+Please review the individual instrumentation READMEs for more information about version compatibility.
 
 ## How can I get involved?
 

--- a/instrumentation/action_view/CHANGELOG.md
+++ b/instrumentation/action_view/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 ### v0.2.0 / 2021-12-01
 
-* ADDED: Move activesupport notification subsciber out of action_view gem 
+* ADDED: Move activesupport notification subscriber out of action_view gem 
 * FIXED: Instrumentation of Rails 7 
 
 ### v0.1.3 / 2021-10-06

--- a/instrumentation/active_model_serializers/CHANGELOG.md
+++ b/instrumentation/active_model_serializers/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 

--- a/instrumentation/all/CHANGELOG.md
+++ b/instrumentation/all/CHANGELOG.md
@@ -179,7 +179,7 @@
 
 ### v0.22.0 / 2021-12-01
 
-* ADDED: Move activesupport notification subsciber out of action_view gem
+* ADDED: Move activesupport notification subscriber out of action_view gem
 
 ### v0.21.3 / 2021-10-07
 
@@ -270,7 +270,7 @@
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Standardize toplevel docs structure and readme
+* DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/aws_sdk/CHANGELOG.md
+++ b/instrumentation/aws_sdk/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### v0.5.1 / 2024-02-08
 
-* FIXED: Return nil for non-existant key in AwsSdk::MessageAttributeGetter
+* FIXED: Return nil for non-existent key in AwsSdk::MessageAttributeGetter
 
 ### v0.5.0 / 2023-09-07
 

--- a/instrumentation/base/CHANGELOG.md
+++ b/instrumentation/base/CHANGELOG.md
@@ -56,7 +56,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 * FIXED: Missing instrumentation classes during configuration
 
 ### v0.17.0 / 2021-04-22

--- a/instrumentation/concurrent_ruby/CHANGELOG.md
+++ b/instrumentation/concurrent_ruby/CHANGELOG.md
@@ -42,7 +42,7 @@
 
 ### v0.19.0 / 2021-09-29
 
-* ADDED: Add suport for `Concurrent::Promises::Future` 
+* ADDED: Add support for `Concurrent::Promises::Future` 
 
 ### v0.18.2 / 2021-08-12
 
@@ -54,7 +54,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
@@ -104,7 +104,7 @@
 ### v0.7.0 / 2020-10-07
 
 * DOCS: Added README for concurrent ruby
-* DOCS: Standardize toplevel docs structure and readme
+* DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/dalli/CHANGELOG.md
+++ b/instrumentation/dalli/CHANGELOG.md
@@ -74,7 +74,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
@@ -123,7 +123,7 @@
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Standardize toplevel docs structure and readme
+* DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/delayed_job/CHANGELOG.md
+++ b/instrumentation/delayed_job/CHANGELOG.md
@@ -65,7 +65,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 * BREAKING CHANGE: Replace Time.now with Process.clock_gettime
 
 ### v0.17.0 / 2021-04-22

--- a/instrumentation/ethon/CHANGELOG.md
+++ b/instrumentation/ethon/CHANGELOG.md
@@ -72,7 +72,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
@@ -128,7 +128,7 @@
 ### v0.7.0 / 2020-10-07
 
 * DOCS: Add README for Ethon
-* DOCS: Standardize toplevel docs structure and readme
+* DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/excon/CHANGELOG.md
+++ b/instrumentation/excon/CHANGELOG.md
@@ -75,7 +75,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 * FIXED: Removed http.status_text attribute #750
 
 ### v0.17.0 / 2021-04-22
@@ -130,7 +130,7 @@
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Standardize toplevel docs structure and readme
+* DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/faraday/CHANGELOG.md
+++ b/instrumentation/faraday/CHANGELOG.md
@@ -91,7 +91,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 * FIXED: Removed http.status_text attribute #750
 
 ### v0.17.0 / 2021-04-22
@@ -144,7 +144,7 @@
 ### v0.7.0 / 2020-10-07
 
 * DOCS: Faraday documentation
-* DOCS: Standardize toplevel docs structure and readme
+* DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/graphql/CHANGELOG.md
+++ b/instrumentation/graphql/CHANGELOG.md
@@ -116,7 +116,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 

--- a/instrumentation/http/CHANGELOG.md
+++ b/instrumentation/http/CHANGELOG.md
@@ -65,7 +65,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 

--- a/instrumentation/http_client/CHANGELOG.md
+++ b/instrumentation/http_client/CHANGELOG.md
@@ -69,7 +69,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 

--- a/instrumentation/lmdb/CHANGELOG.md
+++ b/instrumentation/lmdb/CHANGELOG.md
@@ -47,7 +47,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 

--- a/instrumentation/mongo/CHANGELOG.md
+++ b/instrumentation/mongo/CHANGELOG.md
@@ -57,7 +57,7 @@
 
 * BREAKING CHANGE: Replace Time.now with Process.clock_gettime
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 * FIXED: Replace Time.now with Process.clock_gettime
 * FIXED: Mongodb test asserting error message
 

--- a/instrumentation/mysql2/CHANGELOG.md
+++ b/instrumentation/mysql2/CHANGELOG.md
@@ -90,7 +90,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 * Fix: Nil value for db.name attribute #744
 
 ### v0.17.0 / 2021-04-22
@@ -146,7 +146,7 @@
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Standardize toplevel docs structure and readme
+* DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/net_http/CHANGELOG.md
+++ b/instrumentation/net_http/CHANGELOG.md
@@ -76,7 +76,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 
@@ -126,7 +126,7 @@
 ### v0.7.0 / 2020-10-07
 
 * DOCS: Added documentation for net_http gem in instrumentation
-* DOCS: Standardize toplevel docs structure and readme
+* DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/pg/CHANGELOG.md
+++ b/instrumentation/pg/CHANGELOG.md
@@ -104,7 +104,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 * ADDED: Add option to postgres instrumentation to disable db.statement
 
 ### v0.17.1 / 2021-04-23

--- a/instrumentation/que/README.md
+++ b/instrumentation/que/README.md
@@ -49,7 +49,7 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
-If you wish the job will be executed in the same logicial trace as a direct
+If you wish the job will be executed in the same logical trace as a direct
 child of the span that enqueued the job then set propagation_style to `child`. By
 default the jobs are just linked together.
 

--- a/instrumentation/rack/CHANGELOG.md
+++ b/instrumentation/rack/CHANGELOG.md
@@ -80,7 +80,7 @@
 
 ### v0.20.1 / 2021-12-01
 
-* FIXED: [Instruentation Rack] Log content type http header 
+* FIXED: [Instrumentation Rack] Log content type http header 
 * FIXED: Use monotonic clock where possible 
 * FIXED: Rack to stop using api env getter 
 
@@ -115,7 +115,7 @@ forwards the uri path.  More details on this is available in the readme.
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 * FIXED: Removed http.status_text attribute #750
 
 ### v0.17.0 / 2021-04-22
@@ -181,7 +181,7 @@ forwards the uri path.  More details on this is available in the readme.
 
 * FIXED: Remove superfluous file from Rack gem
 * DOCS: Added README for Rack Instrumentation
-* DOCS: Standardize toplevel docs structure and readme
+* DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/rails/CHANGELOG.md
+++ b/instrumentation/rails/CHANGELOG.md
@@ -87,7 +87,7 @@
 
 ### v0.20.0 / 2021-12-01
 
-* ADDED: Move activesupport notification subsciber out of action_view gem
+* ADDED: Move activesupport notification subscriber out of action_view gem
 * FIXED: Instrumentation of Rails 7
 
 ### v0.19.4 / 2021-10-06
@@ -123,7 +123,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 

--- a/instrumentation/rdkafka/CHANGELOG.md
+++ b/instrumentation/rdkafka/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### v0.4.1 / 2023-11-22
 
-* FIXED: Get Rdkafka version from VERSION contant
+* FIXED: Get Rdkafka version from VERSION constant
 
 ### v0.4.0 / 2023-09-07
 

--- a/instrumentation/redis/CHANGELOG.md
+++ b/instrumentation/redis/CHANGELOG.md
@@ -82,7 +82,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 refactor: redis attribute utils [#760](https://github.com/open-telemetry/opentelemetry-ruby/pull/760)
 refactor: simplify redis attribute assignment [#758](https://github.com/open-telemetry/opentelemetry-ruby/pull/758)
 test: split redis instrumentation test [#754](https://github.com/open-telemetry/opentelemetry-ruby/pull/754)
@@ -145,7 +145,7 @@ test: split redis instrumentation test [#754](https://github.com/open-telemetry/
 ### v0.7.0 / 2020-10-07
 
 * DOCS: Added redis documentation
-* DOCS: Standardize toplevel docs structure and readme
+* DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/restclient/CHANGELOG.md
+++ b/instrumentation/restclient/CHANGELOG.md
@@ -65,7 +65,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 * FIXED: Removed http.status_text attribute #750
 
 ### v0.17.0 / 2021-04-22
@@ -119,7 +119,7 @@
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Standardize toplevel docs structure and readme
+* DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/ruby_kafka/CHANGELOG.md
+++ b/instrumentation/ruby_kafka/CHANGELOG.md
@@ -62,7 +62,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 

--- a/instrumentation/sidekiq/CHANGELOG.md
+++ b/instrumentation/sidekiq/CHANGELOG.md
@@ -103,7 +103,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 * TEST: update test for redis instrumentation refactor [#760](https://github.com/open-telemetry/opentelemetry-ruby/pull/760)
 * BREAKING CHANGE: Remove optional parent_context from in_span
 
@@ -161,7 +161,7 @@
 
 * DOCS: Adding README for Sidekiq instrumentation
 * DOCS: Remove duplicate reference in Sidekiq README
-* DOCS: Standardize toplevel docs structure and readme
+* DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/sinatra/CHANGELOG.md
+++ b/instrumentation/sinatra/CHANGELOG.md
@@ -90,7 +90,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 * BREAKING CHANGE: Remove optional parent_context from in_span
 
 * FIXED: Remove optional parent_context from in_span
@@ -150,7 +150,7 @@
 ### v0.7.0 / 2020-10-07
 
 * FIXED: Default to sinatra.route for span name
-* DOCS: Standardize toplevel docs structure and readme
+* DOCS: Standardize top-level docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/propagator/ottrace/CHANGELOG.md
+++ b/propagator/ottrace/CHANGELOG.md
@@ -46,7 +46,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 
 ### v0.17.0 / 2021-04-22
 

--- a/propagator/xray/CHANGELOG.md
+++ b/propagator/xray/CHANGELOG.md
@@ -34,7 +34,7 @@
 
 ### v0.18.0 / 2021-05-21
 
-* ADDED: Updated API depedency for 1.0.0.rc1
+* ADDED: Updated API dependency for 1.0.0.rc1
 * FIXED: XRay trace_id parsing length
 
 ### v0.17.0 / 2021-04-22


### PR DESCRIPTION
This PR adds [cspell](https://cspell.org/) to the CI to check spelling on markdown docs, adds a new `.cspell.yml` file for configuration, and corrects current mispellings.