### PR TITLE
feat: HTTPClient semantic convention stability migration

### DIFF
--- a/.instrumentation_generator/templates/Gemfile
+++ b/.instrumentation_generator/templates/Gemfile
@@ -20,7 +20,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.17.1'
   gem 'webmock', '~> 3.24'

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@
 source 'https://rubygems.org'
 
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.75.1'
+gem 'rubocop', '~> 1.76.2'
 gem 'rubocop-performance', '~> 1.24.0'

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ The Ruby special interest group (SIG) meets regularly. See the OpenTelemetry
 - [Robert Laurin](https://github.com/robertlaurin), Shopify
 - [Sam Handler](https://github.com/plantfansam), Shopify
 
-For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
+For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
 
 ### Approvers
 
 - [Josef Šimánek](https://github.com/simi)
 - [Xuan Cao](https://github.com/xuan-cao-swi), Solarwinds
 
-For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).
+For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
 
 ## Instrumentation Libraries
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The Ruby special interest group (SIG) meets regularly. See the OpenTelemetry
 
 ### Maintainers
 
+- [Andrew Hayworth](https://github.com/ahayworth)
 - [Ariel Valentin](https://github.com/arielvalentin), GitHub
 - [Daniel Azuma](https://github.com/dazuma), Google
 - [Eric Mustin](https://github.com/ericmustin)

--- a/README.md
+++ b/README.md
@@ -25,14 +25,7 @@ requests.
 The Ruby special interest group (SIG) meets regularly. See the OpenTelemetry
 [community page][ruby-sig] repo for information on this and other language SIGs.
 
-Approvers ([@open-telemetry/ruby-contrib-approvers](https://github.com/orgs/open-telemetry/teams/ruby-contrib-approvers)):
-
-- [Josef Šimánek](https://github.com/simi)
-- [Xuan Cao](https://github.com/xuan-cao-swi), Solarwinds
-
-*Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).*
-
-Maintainers ([@open-telemetry/ruby-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/ruby-contrib-maintainers)):
+### Maintainers
 
 - [Ariel Valentin](https://github.com/arielvalentin), GitHub
 - [Daniel Azuma](https://github.com/dazuma), Google
@@ -44,7 +37,14 @@ Maintainers ([@open-telemetry/ruby-contrib-maintainers](https://github.com/orgs/
 - [Robert Laurin](https://github.com/robertlaurin), Shopify
 - [Sam Handler](https://github.com/plantfansam), Shopify
 
-*Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).*
+For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
+
+### Approvers
+
+- [Josef Šimánek](https://github.com/simi)
+- [Xuan Cao](https://github.com/xuan-cao-swi), Solarwinds
+
+For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).
 
 ## Instrumentation Libraries
 

--- a/helpers/mysql/Gemfile
+++ b/helpers/mysql/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/helpers/sql-obfuscation/Gemfile
+++ b/helpers/sql-obfuscation/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/helpers/sql/Gemfile
+++ b/helpers/sql/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/action_mailer/Gemfile
+++ b/instrumentation/action_mailer/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/action_pack/Gemfile
+++ b/instrumentation/action_pack/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/action_view/Gemfile
+++ b/instrumentation/action_view/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/active_job/Gemfile
+++ b/instrumentation/active_job/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/active_model_serializers/Gemfile
+++ b/instrumentation/active_model_serializers/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/active_record/Gemfile
+++ b/instrumentation/active_record/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/active_storage/Gemfile
+++ b/instrumentation/active_storage/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/active_support/Gemfile
+++ b/instrumentation/active_support/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/all/Gemfile
+++ b/instrumentation/all/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/aws_lambda/Gemfile
+++ b/instrumentation/aws_lambda/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/aws_sdk/Gemfile
+++ b/instrumentation/aws_sdk/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/base/Gemfile
+++ b/instrumentation/base/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/bunny/Gemfile
+++ b/instrumentation/bunny/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/concurrent_ruby/Gemfile
+++ b/instrumentation/concurrent_ruby/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/dalli/Gemfile
+++ b/instrumentation/dalli/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/delayed_job/Gemfile
+++ b/instrumentation/delayed_job/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job_test.rb
+++ b/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job_test.rb
@@ -55,9 +55,11 @@ describe OpenTelemetry::Instrumentation::DelayedJob do
 
     it 'after job' do
       payload = Class.new do
+        # rubocop:disable Naming/PredicateMethod
         def perform
           true
         end
+        # rubocop:enable Naming/PredicateMethod
       end
 
       job = Delayed::Job.enqueue(payload.new)

--- a/instrumentation/ethon/Gemfile
+++ b/instrumentation/ethon/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/excon/Gemfile
+++ b/instrumentation/excon/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/faraday/Gemfile
+++ b/instrumentation/faraday/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/grape/Gemfile
+++ b/instrumentation/grape/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/graphql/Gemfile
+++ b/instrumentation/graphql/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/grpc/Gemfile
+++ b/instrumentation/grpc/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.4'
   gem 'rake', '~> 13.2'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/gruf/Gemfile
+++ b/instrumentation/gruf/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'rake', '~> 12.3.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/http/CHANGELOG.md
+++ b/instrumentation/http/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History: opentelemetry-instrumentation-http
 
+### v0.25.1 / 2025-07-01
+
+* FIXED: Update span name when semconv stability is enabled
+
 ### v0.25.0 / 2025-06-17
 
 * ADDED: Add `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable [#1547](https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1547)

--- a/instrumentation/http/Gemfile
+++ b/instrumentation/http/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/dup/client.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/dup/client.rb
@@ -65,12 +65,12 @@ module OpenTelemetry
             def create_request_span_name(request_method, request_path)
               if (implementation = config[:span_name_formatter])
                 updated_span_name = implementation.call(request_method, request_path)
-                updated_span_name.is_a?(String) ? updated_span_name : "HTTP #{request_method}"
+                updated_span_name.is_a?(String) ? updated_span_name : request_method.to_s
               else
-                "HTTP #{request_method}"
+                request_method.to_s
               end
             rescue StandardError
-              "HTTP #{request_method}"
+              request_method.to_s
             end
 
             def tracer

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/dup/connection.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/dup/connection.rb
@@ -22,7 +22,7 @@ module OpenTelemetry
                 'server.port' => req.uri.port
               }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
-              tracer.in_span('HTTP CONNECT', attributes: attributes) do
+              tracer.in_span('CONNECT', attributes: attributes) do
                 super
               end
             end

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/stable/client.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/stable/client.rb
@@ -56,12 +56,12 @@ module OpenTelemetry
             def create_request_span_name(request_method, request_path)
               if (implementation = config[:span_name_formatter])
                 updated_span_name = implementation.call(request_method, request_path)
-                updated_span_name.is_a?(String) ? updated_span_name : "HTTP #{request_method}"
+                updated_span_name.is_a?(String) ? updated_span_name : request_method.to_s
               else
-                "HTTP #{request_method}"
+                request_method.to_s
               end
             rescue StandardError
-              "HTTP #{request_method}"
+              request_method.to_s
             end
 
             def tracer

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/stable/connection.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/stable/connection.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
                 'server.port' => req.uri.port
               }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
-              tracer.in_span('HTTP CONNECT', attributes: attributes) do
+              tracer.in_span('CONNECT', attributes: attributes) do
                 super
               end
             end

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/version.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/version.rb
@@ -7,7 +7,7 @@
 module OpenTelemetry
   module Instrumentation
     module HTTP
-      VERSION = '0.25.0'
+      VERSION = '0.25.1'
     end
   end
 end

--- a/instrumentation/http/test/instrumentation/http/patches/dup/client_test.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/dup/client_test.rb
@@ -48,7 +48,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Client do
     it 'traces a simple request' do
       HTTP.get('http://example.com/success')
       _(exporter.finished_spans.size).must_equal(1)
-      _(span.name).must_equal 'HTTP GET'
+      _(span.name).must_equal 'GET'
       # Old semantic conventions
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.scheme']).must_equal 'http'
@@ -77,7 +77,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Client do
       HTTP.post('http://example.com/failure')
 
       _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'HTTP POST'
+      _(span.name).must_equal 'POST'
       # Old semantic conventions
       _(span.attributes['http.method']).must_equal 'POST'
       _(span.attributes['http.scheme']).must_equal 'http'
@@ -107,7 +107,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Client do
       end.must_raise HTTP::TimeoutError
 
       _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'HTTP GET'
+      _(span.name).must_equal 'GET'
       # Old semantic conventions
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.scheme']).must_equal 'https'
@@ -143,7 +143,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Client do
       end
 
       _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'HTTP GET'
+      _(span.name).must_equal 'GET'
       # Old semantic conventions
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.scheme']).must_equal 'http'
@@ -172,7 +172,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Client do
       let(:span_name_formatter) do
         # demonstrate simple addition of path and string to span name:
         lambda { |request_method, request_path|
-          "HTTP #{request_method} #{request_path} miniswan"
+          "#{request_method} #{request_path} miniswan"
         }
       end
 
@@ -182,7 +182,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Client do
         end
 
         _(exporter.finished_spans.size).must_equal 1
-        _(span.name).must_equal 'HTTP GET /success miniswan'
+        _(span.name).must_equal 'GET /success miniswan'
         # Old semantic conventions
         _(span.attributes['http.method']).must_equal 'GET'
         _(span.attributes['http.scheme']).must_equal 'http'
@@ -221,7 +221,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Client do
         end
 
         _(exporter.finished_spans.size).must_equal 1
-        _(span.name).must_equal 'HTTP GET'
+        _(span.name).must_equal 'GET'
         # Old semantic conventions
         _(span.attributes['http.method']).must_equal 'GET'
         _(span.attributes['http.scheme']).must_equal 'http'

--- a/instrumentation/http/test/instrumentation/http/patches/dup/connection_test.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/dup/connection_test.rb
@@ -41,7 +41,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Dup::Connection do
       end
 
       _(exporter.finished_spans.size).must_equal(2)
-      _(span.name).must_equal 'HTTP CONNECT'
+      _(span.name).must_equal 'CONNECT'
       # Old semantic conventions
       _(span.attributes['net.peer.name']).must_equal('localhost')
       _(span.attributes['net.peer.port']).wont_be_nil

--- a/instrumentation/http/test/instrumentation/http/patches/stable/client_test.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/stable/client_test.rb
@@ -49,7 +49,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
     it 'traces a simple request' do
       HTTP.get('http://example.com/success')
       _(exporter.finished_spans.size).must_equal(1)
-      _(span.name).must_equal 'HTTP GET'
+      _(span.name).must_equal 'GET'
       _(span.attributes['http.request.method']).must_equal 'GET'
       _(span.attributes['url.scheme']).must_equal 'http'
       _(span.attributes['http.response.status_code']).must_equal 200
@@ -69,7 +69,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
       HTTP.post('http://example.com/failure')
 
       _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'HTTP POST'
+      _(span.name).must_equal 'POST'
       _(span.attributes['http.request.method']).must_equal 'POST'
       _(span.attributes['url.scheme']).must_equal 'http'
       _(span.attributes['http.response.status_code']).must_equal 500
@@ -91,7 +91,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
       end.must_raise HTTP::TimeoutError
 
       _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'HTTP GET'
+      _(span.name).must_equal 'GET'
       _(span.attributes['http.request.method']).must_equal 'GET'
       _(span.attributes['url.scheme']).must_equal 'https'
       _(span.attributes['http.response.status_code']).must_be_nil
@@ -119,7 +119,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
       end
 
       _(exporter.finished_spans.size).must_equal 1
-      _(span.name).must_equal 'HTTP GET'
+      _(span.name).must_equal 'GET'
       _(span.attributes['http.request.method']).must_equal 'GET'
       _(span.attributes['url.scheme']).must_equal 'http'
       _(span.attributes['http.response.status_code']).must_equal 200
@@ -139,7 +139,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
       let(:span_name_formatter) do
         # demonstrate simple addition of path and string to span name:
         lambda { |request_method, request_path|
-          "HTTP #{request_method} #{request_path} miniswan"
+          "#{request_method} #{request_path} miniswan"
         }
       end
 
@@ -149,7 +149,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
         end
 
         _(exporter.finished_spans.size).must_equal 1
-        _(span.name).must_equal 'HTTP GET /success miniswan'
+        _(span.name).must_equal 'GET /success miniswan'
         _(span.attributes['http.request.method']).must_equal 'GET'
         _(span.attributes['url.scheme']).must_equal 'http'
         _(span.attributes['http.response.status_code']).must_equal 200
@@ -179,7 +179,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Client do
         end
 
         _(exporter.finished_spans.size).must_equal 1
-        _(span.name).must_equal 'HTTP GET'
+        _(span.name).must_equal 'GET'
         _(span.attributes['http.request.method']).must_equal 'GET'
         _(span.attributes['url.scheme']).must_equal 'http'
         _(span.attributes['http.response.status_code']).must_equal 200

--- a/instrumentation/http/test/instrumentation/http/patches/stable/connection.rb
+++ b/instrumentation/http/test/instrumentation/http/patches/stable/connection.rb
@@ -41,7 +41,7 @@ describe OpenTelemetry::Instrumentation::HTTP::Patches::Stable::Connection do
       end
 
       _(exporter.finished_spans.size).must_equal(2)
-      _(span.name).must_equal 'HTTP CONNECT'
+      _(span.name).must_equal 'CONNECT'
       _(span.attributes['server.address']).must_equal('localhost')
       _(span.attributes['server.port']).wont_be_nil
     ensure

--- a/instrumentation/http_client/Gemfile
+++ b/instrumentation/http_client/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/httpx/Gemfile
+++ b/instrumentation/httpx/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/koala/Gemfile
+++ b/instrumentation/koala/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/lmdb/Gemfile
+++ b/instrumentation/lmdb/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/mongo/Gemfile
+++ b/instrumentation/mongo/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/mysql2/Gemfile
+++ b/instrumentation/mysql2/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/net_http/Gemfile
+++ b/instrumentation/net_http/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0.1'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/pg/Gemfile
+++ b/instrumentation/pg/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/que/Gemfile
+++ b/instrumentation/que/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/racecar/Gemfile
+++ b/instrumentation/racecar/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
   gem 'rspec-mocks'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/rack/Gemfile
+++ b/instrumentation/rack/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-sdk-experimental', '~> 0.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/rails/Gemfile
+++ b/instrumentation/rails/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rack-test', '~> 2.1.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/rake/Gemfile
+++ b/instrumentation/rake/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/rdkafka/Gemfile
+++ b/instrumentation/rdkafka/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/redis/Gemfile
+++ b/instrumentation/redis/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/resque/Gemfile
+++ b/instrumentation/resque/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/restclient/Gemfile
+++ b/instrumentation/restclient/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/rspec/Gemfile
+++ b/instrumentation/rspec/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/ruby_kafka/Gemfile
+++ b/instrumentation/ruby_kafka/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/sidekiq/Gemfile
+++ b/instrumentation/sidekiq/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/instrumentation/sinatra/Gemfile
+++ b/instrumentation/sinatra/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rack-test', '~> 2.1'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/instrumentation/trilogy/Gemfile
+++ b/instrumentation/trilogy/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-test-helpers', '~> 0.3'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/processor/baggage/Gemfile
+++ b/processor/baggage/Gemfile
@@ -10,7 +10,7 @@ group :test do
   gem 'minitest', '~> 5.0'
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/propagator/google_cloud_trace_context/Gemfile
+++ b/propagator/google_cloud_trace_context/Gemfile
@@ -8,7 +8,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/propagator/ottrace/Gemfile
+++ b/propagator/ottrace/Gemfile
@@ -9,7 +9,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/propagator/vitess/Gemfile
+++ b/propagator/vitess/Gemfile
@@ -9,7 +9,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/propagator/xray/Gemfile
+++ b/propagator/xray/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/resources/aws/Gemfile
+++ b/resources/aws/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.2'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/resources/aws/lib/opentelemetry/resource/detector/aws/ecs.rb
+++ b/resources/aws/lib/opentelemetry/resource/detector/aws/ecs.rb
@@ -52,7 +52,7 @@ module OpenTelemetry
               task_metadata = JSON.parse(http_get("#{metadata_uri_v4}/task"))
 
               task_arn = task_metadata['TaskARN']
-              base_arn = task_arn[0..task_arn.rindex(':') - 1]
+              base_arn = task_arn[0..(task_arn.rindex(':') - 1)]
 
               cluster = task_metadata['Cluster']
               cluster_arn = cluster.start_with?('arn:') ? cluster : "#{base_arn}:cluster/#{cluster}"

--- a/resources/azure/Gemfile
+++ b/resources/azure/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/resources/container/Gemfile
+++ b/resources/container/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/resources/google_cloud_platform/Gemfile
+++ b/resources/google_cloud_platform/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.1'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'webmock', '~> 3.24'

--- a/sampler/xray/Gemfile
+++ b/sampler/xray/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'bundler', '~> 2.4'
   gem 'minitest', '~> 5.0'
   gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.75.2'
+  gem 'rubocop', '~> 1.76.2'
   gem 'rubocop-performance', '~> 1.24.0'
   gem 'simplecov', '~> 0.22.0'
   gem 'yard', '~> 0.9'

--- a/sampler/xray/lib/opentelemetry/sampler/xray/sampling_rule_applier.rb
+++ b/sampler/xray/lib/opentelemetry/sampler/xray/sampling_rule_applier.rb
@@ -68,7 +68,7 @@ module OpenTelemetry
             http_target = '/'
           end
 
-          OpenTelemetry::Sampler::XRay::Utils.attribute_match(attributes, @sampling_rule.attributes) &&
+          OpenTelemetry::Sampler::XRay::Utils.attribute_match?(attributes, @sampling_rule.attributes) &&
             OpenTelemetry::Sampler::XRay::Utils.wildcard_match(@sampling_rule.host, http_host) &&
             OpenTelemetry::Sampler::XRay::Utils.wildcard_match(@sampling_rule.http_method, http_method) &&
             OpenTelemetry::Sampler::XRay::Utils.wildcard_match(@sampling_rule.service_name, service_name) &&

--- a/sampler/xray/lib/opentelemetry/sampler/xray/utils.rb
+++ b/sampler/xray/lib/opentelemetry/sampler/xray/utils.rb
@@ -45,7 +45,7 @@ module OpenTelemetry
           match
         end
 
-        def attribute_match(attributes = nil, rule_attributes = nil)
+        def attribute_match?(attributes = nil, rule_attributes = nil)
           return true if rule_attributes.nil? || rule_attributes.empty?
 
           return false if attributes.nil? ||

--- a/sampler/xray/test/utils_test.rb
+++ b/sampler/xray/test/utils_test.rb
@@ -99,9 +99,9 @@ describe OpenTelemetry::Sampler::XRay::Utils do
 
   it 'test_attribute_match_with_undefined_attributes' do
     rule_attributes = { 'string' => 'string', 'string2' => 'string2' }
-    refute OpenTelemetry::Sampler::XRay::Utils.attribute_match(nil, rule_attributes)
-    refute OpenTelemetry::Sampler::XRay::Utils.attribute_match({}, rule_attributes)
-    refute OpenTelemetry::Sampler::XRay::Utils.attribute_match({ 'string' => 'string' }, rule_attributes)
+    refute OpenTelemetry::Sampler::XRay::Utils.attribute_match?(nil, rule_attributes)
+    refute OpenTelemetry::Sampler::XRay::Utils.attribute_match?({}, rule_attributes)
+    refute OpenTelemetry::Sampler::XRay::Utils.attribute_match?({ 'string' => 'string' }, rule_attributes)
   end
 
   it 'test_attribute_match_with_undefined_rule_attributes' do
@@ -111,19 +111,19 @@ describe OpenTelemetry::Sampler::XRay::Utils do
       'undefined' => nil,
       'boolean' => true
     }
-    assert OpenTelemetry::Sampler::XRay::Utils.attribute_match(attr, nil)
+    assert OpenTelemetry::Sampler::XRay::Utils.attribute_match?(attr, nil)
   end
 
   it 'test_attribute_match_successful_match' do
     attr = { 'language' => 'english' }
     rule_attribute = { 'language' => 'en*sh' }
-    assert OpenTelemetry::Sampler::XRay::Utils.attribute_match(attr, rule_attribute)
+    assert OpenTelemetry::Sampler::XRay::Utils.attribute_match?(attr, rule_attribute)
   end
 
   it 'test_attribute_match_failed_match' do
     attr = { 'language' => 'french' }
     rule_attribute = { 'language' => 'en*sh' }
-    refute OpenTelemetry::Sampler::XRay::Utils.attribute_match(attr, rule_attribute)
+    refute OpenTelemetry::Sampler::XRay::Utils.attribute_match?(attr, rule_attribute)
   end
 
   it 'test_attribute_match_extra_attributes_success' do
@@ -134,7 +134,7 @@ describe OpenTelemetry::Sampler::XRay::Utils do
       'boolean' => true
     }
     rule_attribute = { 'string' => 'string' }
-    assert OpenTelemetry::Sampler::XRay::Utils.attribute_match(attr, rule_attribute)
+    assert OpenTelemetry::Sampler::XRay::Utils.attribute_match?(attr, rule_attribute)
   end
 
   it 'test_attribute_match_extra_attributes_failure' do
@@ -145,6 +145,6 @@ describe OpenTelemetry::Sampler::XRay::Utils do
       'boolean' => true
     }
     rule_attribute = { 'string' => 'string', 'number' => '1' }
-    refute OpenTelemetry::Sampler::XRay::Utils.attribute_match(attr, rule_attribute)
+    refute OpenTelemetry::Sampler::XRay::Utils.attribute_match?(attr, rule_attribute)
   end
 end


### PR DESCRIPTION
This PR is intended to assist in the transition from the old to new HTTP semantic conventions. Per the [HTTP semantic convention stability migration spec](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/), users should be able to set the environment variable `OTEL_SEMCONV_STABILITY_OPT_IN` to:
- `http` to emit stable conventions only
- `http/dup` to emit both old and the stable conventions
-  a blank env var will emit old conventions only

* *Span names have also changed.* Spans will now be named based on only their method. For example, what used to be `HTTP GET` is now just `GET` - [spec](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/#http-client-span-name)

The agent is required to maintain this bridge for 6 months and may drop the environment variable in the next major version and emit only the stable HTTP and networking conventions.

This approach was approved in https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1547